### PR TITLE
Selection Render Overhaul

### DIFF
--- a/map_normalizer/common/inc/MapData.h
+++ b/map_normalizer/common/inc/MapData.h
@@ -32,7 +32,6 @@ namespace MapNormalizer {
             bool isClosed() const;
 
             void setLabelMatrix(uint32_t[]);
-            void setLabelMatrix(InternalMapType32);
 
             ////////////////////////////////////////////////////////////////////
 
@@ -62,6 +61,9 @@ namespace MapNormalizer {
             // More map representations as necessary
 
             bool m_closed;
+
+        public:
+            void setLabelMatrix(InternalMapType32);
     };
 }
 

--- a/map_normalizer/common/inc/MapData.h
+++ b/map_normalizer/common/inc/MapData.h
@@ -14,6 +14,9 @@ namespace MapNormalizer {
             using MapType = std::weak_ptr<uint8_t[]>;
             using ConstMapType = std::weak_ptr<const uint8_t[]>;
 
+            using MapType32 = std::weak_ptr<uint32_t[]>;
+            using ConstMapType32 = std::weak_ptr<const uint32_t[]>;
+
             MapData(uint32_t, uint32_t);
             MapData(MapData&&) = default;
 
@@ -28,6 +31,9 @@ namespace MapNormalizer {
 
             bool isClosed() const;
 
+            void setLabelMatrix(uint32_t[]);
+            void setLabelMatrix(InternalMapType32);
+
             ////////////////////////////////////////////////////////////////////
 
             MapType getInput();
@@ -39,8 +45,12 @@ namespace MapNormalizer {
             MapType getProvinceOutlines();
             ConstMapType getProvinceOutlines() const;
 
+            MapType32 getLabelMatrix();
+            ConstMapType32 getLabelMatrix() const;
+
         private:
             using InternalMapType = std::shared_ptr<uint8_t[]>;
+            using InternalMapType32 = std::shared_ptr<uint32_t[]>;
 
             uint32_t m_width;
             uint32_t m_height;
@@ -48,6 +58,7 @@ namespace MapNormalizer {
             InternalMapType m_input;
             InternalMapType m_provinces;
             InternalMapType m_province_outlines;
+            InternalMapType32 m_label_matrix;
             // More map representations as necessary
 
             bool m_closed;

--- a/map_normalizer/common/src/MapData.cpp
+++ b/map_normalizer/common/src/MapData.cpp
@@ -7,7 +7,8 @@ MapNormalizer::MapData::MapData(uint32_t width, uint32_t height):
     m_height(height),
     m_input(new uint8_t[width * height * 3]{ 0 }),
     m_provinces(new uint8_t[width * height * 3]{ 0 }),
-    m_province_outlines(new uint8_t[width * height * 4]{ 0 })
+    m_province_outlines(new uint8_t[width * height * 4]{ 0 }),
+    m_closed(false)
 {
 }
 

--- a/map_normalizer/common/src/MapData.cpp
+++ b/map_normalizer/common/src/MapData.cpp
@@ -32,6 +32,14 @@ bool MapNormalizer::MapData::isClosed() const {
     return m_closed;
 }
 
+void MapNormalizer::MapData::setLabelMatrix(uint32_t label_matrix[]) {
+    m_label_matrix.reset(label_matrix);
+}
+
+void MapNormalizer::MapData::setLabelMatrix(InternalMapType32 label_matrix) {
+    m_label_matrix = label_matrix;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 auto MapNormalizer::MapData::getInput() -> MapType {
@@ -56,5 +64,13 @@ auto MapNormalizer::MapData::getProvinceOutlines() -> MapType {
 
 auto MapNormalizer::MapData::getProvinceOutlines() const -> ConstMapType {
     return m_province_outlines;
+}
+
+auto MapNormalizer::MapData::getLabelMatrix() -> MapType32 {
+    return m_label_matrix;
+}
+
+auto MapNormalizer::MapData::getLabelMatrix() const -> ConstMapType32 {
+    return m_label_matrix;
 }
 

--- a/map_normalizer/gui/CMakeLists.txt
+++ b/map_normalizer/gui/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(gui STATIC
 
 target_include_directories(gui PUBLIC inc)
 
-target_link_libraries(gui gtkmm native_dialogs)
+target_link_libraries(gui gtkmm native_dialogs stdc++fs)
 
 add_subdirectory(gl)
 

--- a/map_normalizer/gui/gl/glsl/province_selection_fragment.glsl
+++ b/map_normalizer/gui/gl/glsl/province_selection_fragment.glsl
@@ -2,14 +2,21 @@
 
 out vec4 FragColor; // Output color value
 
-uniform sampler2D selection_area;
 uniform sampler2D selection;
+uniform usampler2D label_matrix;
+
+uniform uint province_label;
 
 in vec2 texture_coords; // Input from vertex shader
 
 void main() {
-    vec4 sel_color1 = texture(selection, texture_coords);
+    vec4 sel_color1 = texture(selection, texture_coords * 16); // TODO: This should either be a constant, or passed in via uniform
 
-    FragColor = vec4(1, 0, 0, texture(selection_area, texture_coords).a) * sel_color1;
+    uint pixel_label = texture(label_matrix, texture_coords).r;
+
+    // Only draw if the label for this fragment/pixel matches the one that is currently selected
+    float alpha = uint(pixel_label == province_label);
+
+    FragColor = sel_color1 * vec4(1, 0, 0, alpha);
 }
 

--- a/map_normalizer/gui/gl/inc/MapDrawingAreaGL.h
+++ b/map_normalizer/gui/gl/inc/MapDrawingAreaGL.h
@@ -50,6 +50,8 @@ namespace MapNormalizer::GUI::GL {
 
             void setupAllUniforms();
 
+            virtual void makeCurrent();
+
         private:
             //! Each supported rendering view/scene, mapped to the valid viewing modes
             std::map<ViewingMode, std::shared_ptr<IRenderingView>> m_rendering_views;

--- a/map_normalizer/gui/gl/inc/MapRenderingViewBase.h
+++ b/map_normalizer/gui/gl/inc/MapRenderingViewBase.h
@@ -41,6 +41,7 @@ namespace MapNormalizer::GUI::GL {
         protected:
             Program& getMapProgram();
             Texture& getMapTexture();
+            Texture& getLabelTexture();
 
             virtual void setupUniforms();
 
@@ -60,6 +61,9 @@ namespace MapNormalizer::GUI::GL {
 
             //! The Texture of the map
             Texture m_texture;
+
+            //! The texture of the label matrix
+            Texture m_label_texture;
     };
 }
 

--- a/map_normalizer/gui/gl/inc/Program.h
+++ b/map_normalizer/gui/gl/inc/Program.h
@@ -15,6 +15,8 @@
 # include "Shader.h"
 
 namespace MapNormalizer::GUI::GL {
+    class Texture;
+
     /**
      * @brief Represents a fully compiled and linked GLSL Shader Program
      */
@@ -48,6 +50,7 @@ namespace MapNormalizer::GUI::GL {
             void use(bool = true);
 
             bool uniform(const std::string&, const std::any&) /* throws */;
+            bool uniform(const std::string&, const Texture&) /* throws */;
 
         private:
             void attachShader(const Shader&);

--- a/map_normalizer/gui/gl/inc/Texture.h
+++ b/map_normalizer/gui/gl/inc/Texture.h
@@ -11,6 +11,7 @@
 # include <typeinfo>
 # include <queue>
 # include <string>
+# include <optional>
 
 namespace MapNormalizer::GUI::GL {
     /**
@@ -45,7 +46,9 @@ namespace MapNormalizer::GUI::GL {
             enum class Format {
                 RED, GREEN, BLUE, ALPHA,
                 RGB,
-                RGBA
+                RGBA,
+                RED32I,
+                RED32UI
             };
 
             /**
@@ -98,20 +101,27 @@ namespace MapNormalizer::GUI::GL {
              *
              * @tparam T The type of data being passed in
              *
-             * @param format The format of the data. Currently, both the CPU-side and
-             *               GPU-side format must match.
+             * @param internal_format The format of the data. Currently, both
+             *                        the CPU-side and GPU-side format must
+             *                        match.
              * @param width The width of the data
              * @param height The height of the data
              * @param data The data to send to the GPU
              */
             template<typename T>
-            void setTextureData(Format format, uint32_t width, uint32_t height, const T* data) {
-                setTextureData(format, width, height,
-                               typeToDataType(typeid(T)), data);
+            void setTextureData(Format internal_format,
+                                uint32_t width, uint32_t height, const T* data,
+                                std::optional<uint32_t> format = std::nullopt)
+            {
+                setTextureData(internal_format, width, height,
+                               typeToDataType(typeid(T)), data, format);
             }
 
-            uint32_t getTextureUnitID();
-            uint32_t getTextureID();
+            uint32_t getTextureUnitID() const;
+            uint32_t getTextureID() const;
+            uint32_t getWidth() const;
+            uint32_t getHeight() const;
+            std::pair<uint32_t, uint32_t> getDimensions() const;
 
             void bind(bool = true);
             uint32_t activate();
@@ -128,7 +138,7 @@ namespace MapNormalizer::GUI::GL {
             static uint32_t unitToGLUnit(Unit);
 
             void setTextureData(Format, uint32_t, uint32_t, uint32_t,
-                                const void*);
+                                const void*, std::optional<uint32_t>);
 
         private:
             //! The texture ID
@@ -139,6 +149,9 @@ namespace MapNormalizer::GUI::GL {
 
             //! The target of this texture
             Target m_target;
+
+            uint32_t m_width;
+            uint32_t m_height;
     };
 }
 

--- a/map_normalizer/gui/gl/src/MapRenderingViewBase.cpp
+++ b/map_normalizer/gui/gl/src/MapRenderingViewBase.cpp
@@ -100,6 +100,26 @@ void MapNormalizer::GUI::GL::MapRenderingViewBase::onMapDataChanged(std::shared_
                                   iwidth, iheight, map_data->getProvinces().lock().get());
     }
     m_texture.bind(false);
+
+    ////////////////////////////////////////////////////////////////////////////
+
+    m_label_texture.setTextureUnitID(Texture::Unit::TEX_UNIT1);
+
+    m_label_texture.bind();
+    {
+        WRITE_DEBUG("Building label matrix texture.");
+        m_label_texture.setWrapping(Texture::Axis::S, Texture::WrapMode::REPEAT);
+        m_label_texture.setWrapping(Texture::Axis::T, Texture::WrapMode::REPEAT);
+
+        m_label_texture.setFiltering(Texture::FilterType::MAG, Texture::Filter::NEAREST);
+        m_label_texture.setFiltering(Texture::FilterType::MIN, Texture::Filter::NEAREST);
+
+        m_label_texture.setTextureData(Texture::Format::RED32UI,
+                                       iwidth, iheight,
+                                       map_data->getLabelMatrix().lock().get(),
+                                       GL_RED_INTEGER);
+    }
+    m_label_texture.bind(false);
 }
 
 void MapNormalizer::GUI::GL::MapRenderingViewBase::beginRender() {
@@ -117,7 +137,7 @@ void MapNormalizer::GUI::GL::MapRenderingViewBase::endRender() {
 }
 
 void MapNormalizer::GUI::GL::MapRenderingViewBase::setupUniforms() {
-    m_program.uniform("map_texture", 0);
+    m_program.uniform("map_texture", m_texture);
 }
 
 /**
@@ -161,6 +181,11 @@ auto MapNormalizer::GUI::GL::MapRenderingViewBase::getMapProgram() -> Program& {
 
 auto MapNormalizer::GUI::GL::MapRenderingViewBase::getMapTexture() -> Texture& {
     return m_texture;
+}
+
+auto MapNormalizer::GUI::GL::MapRenderingViewBase::getLabelTexture() -> Texture&
+{
+    return m_label_texture;
 }
 
 auto MapNormalizer::GUI::GL::MapRenderingViewBase::getPrograms() -> ProgramList {

--- a/map_normalizer/gui/gl/src/Program.cpp
+++ b/map_normalizer/gui/gl/src/Program.cpp
@@ -16,9 +16,12 @@
 #include <glm/mat4x4.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
+#include "Types.h"
+
 #include "Logger.h"
 
 #include "GLUtils.h"
+#include "Texture.h"
 
 MapNormalizer::GUI::GL::Program::LinkException::LinkException(const std::string& reason):
     m_reason(reason)
@@ -146,6 +149,8 @@ bool MapNormalizer::GUI::GL::Program::uniform(const std::string& uniform_name,
         glUniform1i(uniform_loc, std::any_cast<bool>(value));
     } else if(value.type() == typeid(int)) {                           // int
         glUniform1i(uniform_loc, std::any_cast<int>(value));
+    } else if(value.type() == typeid(uint32_t)) {                      // unsigned int
+        glUniform1ui(uniform_loc, std::any_cast<uint32_t>(value));
     } else if(value.type() == typeid(float)) {                         // float
         glUniform1f(uniform_loc, std::any_cast<float>(value));
     } else if(value.type() == typeid(glm::vec2)) {                     // vec2
@@ -154,6 +159,9 @@ bool MapNormalizer::GUI::GL::Program::uniform(const std::string& uniform_name,
     } else if(value.type() == typeid(glm::vec3)) {                     // vec3
         glUniform3fv(uniform_loc, 1,
                      glm::value_ptr(std::any_cast<glm::vec3>(value)));
+    } else if(value.type() == typeid(Color)) {                         // Color
+        auto&& color = std::any_cast<Color>(value);
+        glUniform3f(uniform_loc, color.r, color.g, color.b);
     } else if(value.type() == typeid(glm::vec4)) {                     // vec4
         glUniform4fv(uniform_loc, 1,
                      glm::value_ptr(std::any_cast<glm::vec4>(value)));
@@ -177,5 +185,11 @@ bool MapNormalizer::GUI::GL::Program::uniform(const std::string& uniform_name,
     }
 
     return true;
+}
+
+bool MapNormalizer::GUI::GL::Program::uniform(const std::string& uniform_name,
+                                              const Texture& value)
+{
+    return uniform(uniform_name, static_cast<int>(value.getTextureUnitID()) - GL_TEXTURE0);
 }
 

--- a/map_normalizer/gui/inc/IMapDrawingArea.h
+++ b/map_normalizer/gui/inc/IMapDrawingArea.h
@@ -26,6 +26,7 @@ namespace MapNormalizer::GUI {
             struct SelectionInfo {
                 Project::MapProject::ProvinceDataPtr data;
                 BoundingBox bounding_box;
+                ProvinceID id;
             };
 
             using SelectionCallback = std::function<void(uint32_t, uint32_t)>;
@@ -180,6 +181,10 @@ namespace MapNormalizer::GUI {
                 }
 
                 return true;
+            }
+
+            virtual void setSizeRequest(int width = -1, int height = -1) {
+                BaseGtkWidget::set_size_request(width, height);
             }
     };
 }

--- a/map_normalizer/gui/src/MainWindow.cpp
+++ b/map_normalizer/gui/src/MainWindow.cpp
@@ -362,7 +362,7 @@ void MapNormalizer::GUI::MainWindow::buildViewPane() {
                     auto preview_data = map_project.getPreviewData(province);
                     m_province_properties_pane->setProvince(province, preview_data);
 
-                    m_drawing_area->setSelection({preview_data, province->bounding_box});
+                    m_drawing_area->setSelection({preview_data, province->bounding_box, province->id});
                     m_drawing_area->queueDraw();
                 }
             }

--- a/map_normalizer/logging/CMakeLists.txt
+++ b/map_normalizer/logging/CMakeLists.txt
@@ -11,6 +11,6 @@ add_library(logging SHARED
 target_include_directories(logging PUBLIC inc)
 
 if(NOT WIN32)
-    target_link_libraries(logging PRIVATE dl)
+    target_link_libraries(logging PRIVATE dl stdc++fs)
 endif()
 

--- a/map_normalizer/project/inc/MapProject.h
+++ b/map_normalizer/project/inc/MapProject.h
@@ -56,6 +56,9 @@ namespace MapNormalizer::Project {
             ProvinceDataPtr getPreviewData(ProvinceID);
             ProvinceDataPtr getPreviewData(const Province*);
 
+            ProvinceList& getProvinces();
+            const ProvinceList& getProvinces() const;
+
         protected:
             bool saveShapeLabels(const std::filesystem::path&,
                                  std::error_code&);

--- a/map_normalizer/project/inc/MapProject.h
+++ b/map_normalizer/project/inc/MapProject.h
@@ -83,7 +83,6 @@ namespace MapNormalizer::Project {
              */
             struct ShapeDetectionInfo {
                 ProvinceList provinces;
-                uint32_t* label_matrix = nullptr;
                 uint32_t label_matrix_size = 0;
 
                 std::shared_ptr<MapData> map_data;

--- a/map_normalizer/project/src/MapProject.cpp
+++ b/map_normalizer/project/src/MapProject.cpp
@@ -562,6 +562,16 @@ auto MapNormalizer::Project::MapProject::getPreviewData(const Province* province
     return data;
 }
 
+auto MapNormalizer::Project::MapProject::getProvinces() const
+    -> const ProvinceList&
+{
+    return m_shape_detection_info.provinces;
+}
+
+auto MapNormalizer::Project::MapProject::getProvinces() -> ProvinceList& {
+    return m_shape_detection_info.provinces;
+}
+
 /**
  * @brief Will build the province preview for the given province. If more than
  *        MAX_CACHED_PROVINCE_PREVIEWS are already stored, then the least

--- a/map_normalizer/project/src/MapProject.cpp
+++ b/map_normalizer/project/src/MapProject.cpp
@@ -114,7 +114,9 @@ bool MapNormalizer::Project::MapProject::load(const std::filesystem::path& path,
 
     // TODO: Why do we actually have to do this? For some reason everything stops
     //  rendering correctly if we remove this line. Why? What? How?
+    auto label_matrix = map_data->getLabelMatrix().lock();
     map_data.reset(new MapData(width, height));
+    map_data->setLabelMatrix(label_matrix); // WHY?!!!!
 
     auto input_data = map_data->getInput().lock();
     auto graphics_data = map_data->getProvinces().lock();
@@ -132,7 +134,7 @@ bool MapNormalizer::Project::MapProject::load(const std::filesystem::path& path,
             //  3 == the depth
             auto gindex = xyToIndex(width * 3, x * 3, y);
 
-            auto label = m_shape_detection_info.label_matrix[lindex];
+            auto label = label_matrix[lindex];
 
             // Error check
             if(label <= 0 || label > m_shape_detection_info.provinces.size()) {
@@ -181,7 +183,7 @@ bool MapNormalizer::Project::MapProject::saveShapeLabels(const std::filesystem::
                        m_shape_detection_info.map_data->getHeight());
 
         // Write the entire label matrix to the file
-        out.write(reinterpret_cast<const char*>(m_shape_detection_info.label_matrix),
+        out.write(reinterpret_cast<const char*>(m_shape_detection_info.map_data->getLabelMatrix().lock().get()),
                   m_shape_detection_info.label_matrix_size * sizeof(uint32_t));
         out << '\0';
     } else {
@@ -290,21 +292,15 @@ bool MapNormalizer::Project::MapProject::loadShapeLabels(const std::filesystem::
         }
 
         auto& label_matrix_size = m_shape_detection_info.label_matrix_size;
-        auto& label_matrix = m_shape_detection_info.label_matrix;
-
-        if(label_matrix != nullptr) {
-            delete[] label_matrix;
-        }
 
         label_matrix_size = width * height;
-        label_matrix = new uint32_t[label_matrix_size];
+        m_shape_detection_info.map_data->setLabelMatrix(new uint32_t[label_matrix_size]);
 
-        if(!safeRead(label_matrix, label_matrix_size * sizeof(uint32_t), in)) {
+        auto label_matrix = m_shape_detection_info.map_data->getLabelMatrix().lock();
+
+        if(!safeRead(label_matrix.get(), label_matrix_size * sizeof(uint32_t), in)) {
             ec = std::error_code(static_cast<int>(errno), std::generic_category());
             WRITE_ERROR("Failed to read full label matrix. Reason: ", std::strerror(errno));
-
-            delete[] label_matrix;
-            label_matrix = nullptr;
             return false;
         }
     } else {
@@ -427,7 +423,7 @@ void MapNormalizer::Project::MapProject::setShapeFinder(ShapeFinder&& shape_find
     ShapeFinder sf(std::move(shape_finder));
 
     m_shape_detection_info.provinces = createProvincesFromShapeList(sf.getShapes());
-    m_shape_detection_info.label_matrix = sf.getLabelMatrix();
+    m_shape_detection_info.map_data->setLabelMatrix(sf.getLabelMatrix());
     m_shape_detection_info.label_matrix_size = sf.getLabelMatrixSize();
     m_shape_detection_info.map_data.reset();
 
@@ -455,7 +451,7 @@ auto MapNormalizer::Project::MapProject::getMapData() const
 }
 
 const uint32_t* MapNormalizer::Project::MapProject::getLabelMatrix() const {
-    return m_shape_detection_info.label_matrix;
+    return m_shape_detection_info.map_data->getLabelMatrix().lock().get();
 }
 
 void MapNormalizer::Project::MapProject::selectProvince(uint32_t label) {
@@ -603,7 +599,7 @@ void MapNormalizer::Project::MapProject::buildProvinceCache(const Province* prov
 
     // Some references first, to make the following code easier to read
     //  id also starts at 1, so make sure we offset it down
-    const auto& label_matrix = m_shape_detection_info.label_matrix;
+    auto label_matrix = m_shape_detection_info.map_data->getLabelMatrix().lock();
     auto iwidth = m_shape_detection_info.map_data->getWidth();
 
     auto&& bb = province.bounding_box;
@@ -675,7 +671,7 @@ void MapNormalizer::Project::MapProject::buildProvinceOutlines() {
     for(uint32_t x = 0; x < width; ++x) {
         for(uint32_t y = 0; y < height; ++y) {
             auto lindex = xyToIndex(width, x, y);
-            auto label = m_shape_detection_info.label_matrix[lindex];
+            auto label = m_shape_detection_info.map_data->getLabelMatrix().lock()[lindex];
             auto gindex = xyToIndex(width * 4, x * 4, y);
 
             auto& province = m_shape_detection_info.provinces[label - 1];
@@ -692,7 +688,7 @@ void MapNormalizer::Project::MapProject::buildProvinceOutlines() {
             // Recalculate adjacencies for this pixel
             auto is_adjacent = ShapeFinder::calculateAdjacency(dimensions,
                                                                graphics_data.get(),
-                                                               m_shape_detection_info.label_matrix,
+                                                               m_shape_detection_info.map_data->getLabelMatrix().lock().get(),
                                                                province.adjacent_provinces,
                                                                {x, y});
             // If this pixel is adjacent to any others, then make it visible as


### PR DESCRIPTION
Overhaul of the selection rendering code to allow eventually rendering a specific texture to multiple provinces at once (this would allow things such as multiselect and rendering textures for different terrain types to give two examples).